### PR TITLE
Use clever's custom go1.4 image for drone.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: go1.4
+image: clever/drone-go:1.4
 notify:
   email:
     recipients:


### PR DESCRIPTION
There is no official go1.4 image for drone. This change modifies the drone.yml to use clever's custom image.
