### PR TITLE
Use a script to run the postgres-to-redshift binary using env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.a
 *.so
 
+# Backup files
+*~
+
 # Folders
 _obj
 _test

--- a/run_as_worker.sh
+++ b/run_as_worker.sh
@@ -6,7 +6,7 @@ gearcmd -name postgres-to-redshift \
   -host=$GEARMAN_HOST \
   -port=$GEARMAN_PORT \
   -parseargs=true \
-  -cmd /usr/local/bin/postgres-to-redshift &
+  -cmd /go/src/github.com/Clever/postgres-to-redshift/run_main.sh &
 pid=$!
 # When we get a SIGTERM, forward it to the child process and call wait. Note that we wait both in here
 # and below (on line 27) because when bash gets a SIGTERM bash appears to cancel the currently running

--- a/run_main.sh
+++ b/run_main.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+/usr/local/bin/postgres-to-redshift \
+-redshifthost=$REDSHIFT_HOST \
+-redshiftport=$REDSHIFT_PORT \
+-redshiftuser=$REDSHIFT_USER \
+-redshiftpassword=$REDSHIFT_PASSWORD \
+-redshiftdatabase=$REDSHIFT_DATABASE \
+-postgreshost=$POSTGRES_HOST \
+-postgresdatabase=$POSTGRES_DATABASE \
+-postgresuser=$POSTGRES_USER \
+-postgresport=$POSTGRES_PORT \
+-postgrespassword=$POSTGRES_PASSWORD \
+-s3prefix=$S3PREFIX \
+-tables=$TABLES_TO_COPY


### PR DESCRIPTION
Previously, the flag values would have to be provided by the gearman command which triggered the execution of the script. This configuration would live in the database which is not an ideal way to version. Following this change, we can use environment variables stored in salt.
