### PR TITLE
Set PoolSize to number of tables in postgres connection

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,13 +12,13 @@
 		},
 		{
 			"ImportPath": "github.com/clever/redshifter/postgres",
-			"Comment": "v1.0.1-10-gf8eace7",
-			"Rev": "f8eace78cebbdf085ade5b58a8fddfa6fd87609c"
+			"Comment": "v2.1.0",
+			"Rev": "bd333cf984493a5bec7e79c61124667d4e6529d2"
 		},
 		{
 			"ImportPath": "github.com/clever/redshifter/redshift",
-			"Comment": "v1.0.1-10-gf8eace7",
-			"Rev": "f8eace78cebbdf085ade5b58a8fddfa6fd87609c"
+			"Comment": "v2.1.0",
+			"Rev": "bd333cf984493a5bec7e79c61124667d4e6529d2"
 		},
 		{
 			"ImportPath": "github.com/facebookgo/errgroup",

--- a/Godeps/_workspace/src/github.com/clever/redshifter/postgres/README.md
+++ b/Godeps/_workspace/src/github.com/clever/redshifter/postgres/README.md
@@ -28,6 +28,16 @@ type ColInfo struct {
 ColInfo is a struct that contains information about a column in a postgreSQL
 database.
 
+#### type Config
+
+```go
+type Config struct {
+	PoolSize int
+}
+```
+
+Config is a struct used to specify configuration for the postgreSQL connection.
+
 #### type DB
 
 ```go
@@ -40,7 +50,7 @@ DB is a struct that is used to perform operations on a postgreSQL database.
 #### func  NewDB
 
 ```go
-func NewDB() *DB
+func NewDB(cfg Config) *DB
 ```
 NewDB returns a DB struct initialized based on flags.
 

--- a/Godeps/_workspace/src/github.com/clever/redshifter/postgres/postgres.go
+++ b/Godeps/_workspace/src/github.com/clever/redshifter/postgres/postgres.go
@@ -49,6 +49,11 @@ type dbQueryCopyToCloser interface {
 	CopyTo(io.WriteCloser, string, ...interface{}) (*pg.Result, error)
 }
 
+// Config is a struct used to specify configuration for the postgreSQL connection.
+type Config struct {
+	PoolSize int
+}
+
 // DB is a struct that is used to perform operations on a postgreSQL database.
 type DB struct {
 	dbQueryCopyToCloser
@@ -56,7 +61,7 @@ type DB struct {
 }
 
 // NewDB returns a DB struct initialized based on flags.
-func NewDB() *DB {
+func NewDB(cfg Config) *DB {
 	flag.Parse()
 	opt := pg.Options{
 		Host:     *host,
@@ -65,6 +70,7 @@ func NewDB() *DB {
 		Password: *pwd,
 		Database: *dbname,
 		SSL:      true,
+		PoolSize: cfg.PoolSize,
 	}
 	return &DB{pg.Connect(&opt), pathio.WriteReader}
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	tables := strings.Split(*tablesCSV, ",")
 
-	pgdb := postgres.NewDB()
+	pgdb := postgres.NewDB(postgres.Config{PoolSize: len(tables)})
 	defer pgdb.Close()
 	tsmap, err := pgdb.GetTableSchemas(tables, "")
 	if err != nil {


### PR DESCRIPTION
For some reason, the driver is not great at releasing the connections or waiting for connections to be released if already full. This causes the program to hang if we dump more than 5 tables in parallel. Increasing the connection pool size to fix it.

Followup to https://github.com/Clever/redshifter/pull/8

Tested: Ran the program locally with the increased pool size and verified that it works.
