### PR TITLE
Use Go 1.6 in Drone and golang-version-check.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: clever/drone-go:1.5
+image: clever/drone-go:1.6
 notify:
   email:
     recipients:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/postgres-to-redshift
 PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := $(shell basename $(PKG))
-$(eval $(call golang-version-check,1.5))
+$(eval $(call golang-version-check,1.6))
 
 all: test build
 


### PR DESCRIPTION
You were assigned as the most active recent contributor to this repo.
Please reassign and share the joy of Go 1.6 if needed, or ask in #golang
if you have any questions.
