### PR TITLE
circle: make build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ machine:
 checkout:
   post:
   - $HOME/ci-scripts/circleci/golang-move-project
+compile:
+  override:
+  - make build
 test:
   post:
   - $HOME/ci-scripts/circleci/report-card $RC_DOCKER_USER $RC_DOCKER_PASS "$RC_DOCKER_EMAIL" $RC_GITHUB_TOKEN


### PR DESCRIPTION
this is neccessary to build the Dockerfile:

Example failure in drone:
https://ci.ops.clever.com/github.com/Clever/postgres-to-redshift/master/67339d1b8bb981cd6c71037530ece3a7fe119156

Example failure in CircleCI:
https://circleci.com/gh/Clever/postgres-to-redshift/4

---

The failure is that the binary doesn't exist:

```
Step 4 : COPY bin/postgres-to-redshift /usr/local/bin/postgres-to-redshift
lstat bin/postgres-to-redshift: no such file or directory
```