### PR TITLE
Update Gearcmd to v0.10.0 -- defaults pass-sigterm to true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 RUN apt-get update && \
     apt-get install -y curl build-essential
 
-RUN curl -L https://github.com/Clever/gearcmd/releases/download/0.8.7/gearcmd-v0.8.7-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
+RUN curl -L https://github.com/Clever/gearcmd/releases/download/0.10.0/gearcmd-v0.10.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
 
 COPY bin/postgres-to-redshift /usr/local/bin/postgres-to-redshift
 CMD ["gearcmd", "--name", "postgres-to-redshift", "--cmd", "/usr/local/bin/postgres-to-redshift"]


### PR DESCRIPTION

Context: https://github.com/Clever/gearcmd/pull/67

We make this the default in order to match signal handling behavior in
sfncli (https://github.com/Clever/sfncli). We want to know ahead of time
if any application isn't handling sigterm correctly before moving to workflows.

Note: If this breaks application behavior, please

(0) set `pass-sigterm=false` in Dockerfile and redeploy
(1) add a note here
(2) let @xavi- or someone on eng-infra know

Thanks!